### PR TITLE
feat/1006: 썸네일 터치시 페이지이동, 동영상 재생 및 카메라 on

### DIFF
--- a/src/navigation/Home.js
+++ b/src/navigation/Home.js
@@ -3,6 +3,8 @@ import { UserAuth } from '../context/AuthContext';
 import { createStackNavigator } from '@react-navigation/stack';
 import Profile from '../screens/Profile';
 import MainNav from './MainNav';
+import Face from '../components/Face';
+import ExerciseScreen from '../screens/ExerciseScreen';
 
 const Stack = createStackNavigator();
 
@@ -23,6 +25,16 @@ export default function Home() {
             <Stack.Screen
               name="mainNav"
               component={MainNav}
+              options={{ headerShown: false }}
+            />
+            <Stack.Screen
+              name="face"
+              component={Face}
+              // options={{ headerShown: false }}
+            />
+            <Stack.Screen
+              name="exerciseScreen"
+              component={ExerciseScreen}
               options={{ headerShown: false }}
             />
           </>

--- a/src/navigation/MainNav.js
+++ b/src/navigation/MainNav.js
@@ -3,9 +3,9 @@ import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { Feather, MaterialCommunityIcons, Entypo } from '@expo/vector-icons';
 import HomeScreen from '../screens/HomeScreen';
 import Trainers from '../screens/Trainers';
-import VideoScreen from '../screens/VideoScreen';
 import EtcScreen from '../screens/EtcScreen';
 import FaceDetect from '../screens/FaceDetect';
+import RecordScreen from '../screens/RecordScreen';
 
 const Tab = createBottomTabNavigator();
 
@@ -45,7 +45,7 @@ export default function MainNav() {
       />
       <Tab.Screen
         name="Record"
-        component={VideoScreen}
+        component={RecordScreen}
         options={{
           tabBarIcon: ({ color }) => (
             <Feather name="video" size={24} color={color} />

--- a/src/navigation/index.js
+++ b/src/navigation/index.js
@@ -1,23 +1,12 @@
-import { View, Text, StyleSheet } from 'react-native';
+import { StyleSheet } from 'react-native';
 import React from 'react';
 import { NavigationContainer } from '@react-navigation/native';
 import { UserAuth } from '../context/AuthContext';
-import { LoadingState } from '../context/LoadingContext';
 import Auth from './Auth';
 import Home from './Home';
-import LoadingCircle from '../components/LoadingCircle';
 
 function NavigationIndex() {
   const { currUser } = UserAuth();
-  const { loading } = LoadingState();
-
-  if (loading) {
-    return (
-      <View style={styles.container}>
-        <LoadingCircle />
-      </View>
-    );
-  }
 
   return (
     <NavigationContainer>{!currUser ? <Auth /> : <Home />}</NavigationContainer>

--- a/src/screens/ExerciseScreen.js
+++ b/src/screens/ExerciseScreen.js
@@ -2,12 +2,12 @@ import React, { useState, useEffect } from 'react';
 import { StyleSheet, Text, View, TouchableOpacity } from 'react-native';
 import { Camera } from 'expo-camera';
 import { Video } from 'expo-av';
+import { StatusBar } from 'expo-status-bar';
+import { MaterialIcons } from '@expo/vector-icons';
 
 export default function ExerciseScreen({ route }) {
   const [permissionStatus, setPermissionStatus] = useState('');
   const [type, setType] = useState('front');
-
-  console.log(route);
 
   useEffect(() => {
     (async () => {
@@ -24,6 +24,7 @@ export default function ExerciseScreen({ route }) {
   }
   return (
     <View style={styles.container}>
+      <StatusBar hidden />
       <Video
         style={styles.video}
         resizeMode="contain"
@@ -31,7 +32,7 @@ export default function ExerciseScreen({ route }) {
         isLooping
         source={route.params.videoURI}
       />
-      <Camera style={styles.camera} type={type}>
+      <Camera style={styles.camera} type={type} ratio={'1:1'}>
         <View style={styles.buttonContainer}>
           <TouchableOpacity
             style={styles.button}
@@ -39,7 +40,11 @@ export default function ExerciseScreen({ route }) {
               setType(type === 'back' ? 'front' : 'back');
             }}
           >
-            <Text style={styles.text}> Flip </Text>
+            <MaterialIcons
+              name="flip-camera-android"
+              size={30}
+              color={'white'}
+            />
           </TouchableOpacity>
         </View>
       </Camera>
@@ -52,13 +57,14 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   video: {
-    flex: 0.9,
+    flex: 0.989,
     width: '100%',
     height: '100%',
   },
   camera: {
     flex: 1,
-    alignSelf: 'auto',
+    width: '100%',
+    height: '100%',
   },
   buttonContainer: {
     flex: 1,
@@ -67,7 +73,7 @@ const styles = StyleSheet.create({
     margin: 20,
   },
   button: {
-    flex: 0.15,
+    flex: 0.1,
     alignSelf: 'flex-start',
     alignItems: 'flex-end',
   },

--- a/src/screens/ExerciseScreen.js
+++ b/src/screens/ExerciseScreen.js
@@ -1,0 +1,79 @@
+import React, { useState, useEffect } from 'react';
+import { StyleSheet, Text, View, TouchableOpacity } from 'react-native';
+import { Camera } from 'expo-camera';
+import { Video } from 'expo-av';
+
+export default function ExerciseScreen({ route }) {
+  const [permissionStatus, setPermissionStatus] = useState('');
+  const [type, setType] = useState('front');
+
+  console.log(route);
+
+  useEffect(() => {
+    (async () => {
+      const { status } = await Camera.requestCameraPermissionsAsync();
+      setPermissionStatus(status === 'granted');
+    })();
+  }, []);
+
+  if (permissionStatus === '') {
+    return <View />;
+  }
+  if (permissionStatus === false) {
+    return <Text>No access to camera</Text>;
+  }
+  return (
+    <View style={styles.container}>
+      <Video
+        style={styles.video}
+        resizeMode="contain"
+        useNativeControls
+        isLooping
+        source={route.params.videoURI}
+      />
+      <Camera style={styles.camera} type={type}>
+        <View style={styles.buttonContainer}>
+          <TouchableOpacity
+            style={styles.button}
+            onPress={() => {
+              setType(type === 'back' ? 'front' : 'back');
+            }}
+          >
+            <Text style={styles.text}> Flip </Text>
+          </TouchableOpacity>
+        </View>
+      </Camera>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  video: {
+    flex: 0.9,
+    width: '100%',
+    height: '100%',
+  },
+  camera: {
+    flex: 1,
+    alignSelf: 'auto',
+  },
+  buttonContainer: {
+    flex: 1,
+    backgroundColor: 'transparent',
+    flexDirection: 'row',
+    margin: 20,
+  },
+  button: {
+    flex: 0.15,
+    alignSelf: 'flex-start',
+    alignItems: 'flex-end',
+  },
+  text: {
+    fontSize: 25,
+    fontWeight: 'bold',
+    color: 'white',
+  },
+});

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -1,9 +1,10 @@
 import React, { useEffect } from 'react';
-import { View, Text, StyleSheet, Image, FlatList } from 'react-native';
+import { View, StyleSheet, Image, FlatList } from 'react-native';
 import * as VideoThumbnails from 'expo-video-thumbnails';
 import { Asset } from 'expo-asset';
 import { ThumbnailState } from '../context/ThumbnailContext';
 import { TouchableOpacity } from 'react-native-gesture-handler';
+import { useNavigation } from '@react-navigation/native';
 
 export default function HomeScreen() {
   const videos = [
@@ -26,6 +27,7 @@ export default function HomeScreen() {
   ];
 
   const { thumbNails, setThumbNails } = ThumbnailState();
+  const navigation = useNavigation();
 
   useEffect(() => {
     const generateThumbnails = async () => {
@@ -44,6 +46,7 @@ export default function HomeScreen() {
           const item = {
             id: index,
             uri: uri,
+            videoURI: element.src,
           };
           thumbNailTemp.push(item);
 
@@ -69,7 +72,11 @@ export default function HomeScreen() {
         marginBottom: 25,
       }}
     >
-      <TouchableOpacity>
+      <TouchableOpacity
+        onPress={() =>
+          navigation.navigate('exerciseScreen', { videoURI: item.videoURI })
+        }
+      >
         <View style={{ justifyContent: 'center', alignItems: 'center' }}>
           <Image
             source={{ uri: item.uri }}
@@ -88,16 +95,6 @@ export default function HomeScreen() {
 
   return (
     <View style={styles.container}>
-      {/* <Video
-        style={styles.video}
-        resizeMode="contain"
-        useNativeControls
-        isLooping
-        source={videos[2].src}
-      /> */}
-      {/* {thumbNails && (
-        <Image source={{ uri: thumbNails }} style={styles.image} />
-      )} */}
       <FlatList
         data={thumbNails}
         renderItem={renderThumbnail}
@@ -115,13 +112,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
     backgroundColor: '#fff',
-  },
-  video: {
-    flex: 1,
-    alignSelf: 'stretch',
-  },
-  buttons: {
-    margin: 16,
   },
   image: {
     width: 200,

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -1,5 +1,7 @@
 import React, { useEffect } from 'react';
 import { View, StyleSheet, Image, FlatList } from 'react-native';
+import { LoadingState } from '../context/LoadingContext';
+import LoadingCircle from '../components/LoadingCircle';
 import * as VideoThumbnails from 'expo-video-thumbnails';
 import { Asset } from 'expo-asset';
 import { ThumbnailState } from '../context/ThumbnailContext';
@@ -26,6 +28,7 @@ export default function HomeScreen() {
     },
   ];
 
+  const { loading, setLoading } = LoadingState();
   const { thumbNails, setThumbNails } = ThumbnailState();
   const navigation = useNavigation();
 
@@ -64,45 +67,46 @@ export default function HomeScreen() {
     generateThumbnails();
   }, []);
 
+  useEffect(() => {
+    if (!thumbNails.length) {
+      setLoading(true);
+    } else {
+      setLoading(false);
+    }
+  }, [thumbNails.length]);
+
   const renderThumbnail = ({ item }) => (
-    <View
-      style={{
-        flexDirection: 'row',
-        justifyContent: 'center',
-        marginBottom: 25,
-      }}
-    >
+    <View style={styles.thumbNailItem}>
       <TouchableOpacity
         onPress={() =>
           navigation.navigate('exerciseScreen', { videoURI: item.videoURI })
         }
       >
-        <View style={{ justifyContent: 'center', alignItems: 'center' }}>
-          <Image
-            source={{ uri: item.uri }}
-            style={{
-              width: 380,
-              height: 200,
-              borderRadius: 10,
-              borderColor: 'black',
-              borderWidth: 1,
-            }}
-          />
+        <View style={styles.imageWrapper}>
+          <Image source={{ uri: item.uri }} style={styles.image} />
         </View>
       </TouchableOpacity>
     </View>
   );
 
   return (
-    <View style={styles.container}>
-      <FlatList
-        data={thumbNails}
-        renderItem={renderThumbnail}
-        keyExtractor={(thumbNail) => thumbNail.id}
-        numColumns={1}
-        style={{ marginTop: 50 }}
-      />
-    </View>
+    <>
+      {loading ? (
+        <View style={styles.container}>
+          <LoadingCircle />
+        </View>
+      ) : (
+        <View style={styles.container}>
+          <FlatList
+            data={thumbNails}
+            renderItem={renderThumbnail}
+            keyExtractor={(thumbNail) => thumbNail.id}
+            numColumns={1}
+            style={{ marginTop: 50 }}
+          />
+        </View>
+      )}
+    </>
   );
 }
 
@@ -113,8 +117,20 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     backgroundColor: '#fff',
   },
+  imageWrapper: {
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
   image: {
-    width: 200,
+    width: 380,
     height: 200,
+    borderRadius: 10,
+    borderColor: 'black',
+    borderWidth: 1,
+  },
+  thumbNailItem: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    marginBottom: 25,
   },
 });

--- a/src/screens/RecordScreen.js
+++ b/src/screens/RecordScreen.js
@@ -1,10 +1,10 @@
 import { View, Text } from 'react-native';
 import React from 'react';
 
-export default function VideoScreen() {
+export default function RecordScreen() {
   return (
     <View style={{ marginTop: 40 }}>
-      <Text>VideoScreen</Text>
+      <Text>RecordScreen</Text>
     </View>
   );
 }


### PR DESCRIPTION
## 개요

- [칸반링크](https://www.notion.so/UI-a525f4afa1fc4157838744799df38bac)
- 이미지를 터치하면 해당 이미지에 해당하는 동영상이 재생되어야 하므로 동영상의 URI값이 필요하였다. 해당 값을 얻기 위해 route props로 내려줘서 구현하였다.

## 작업사항
![Screenshot_20220703-181021_Expo Go](https://user-images.githubusercontent.com/102529818/177033106-007e5126-9088-4610-9d01-af3548510d75.jpg)
- 썸네일 터치하면 운동페이지로 이동
- 운동동영상과 사용자의 카메라를 나눠서 표시
- 메인페이지 로딩서클 추가