### PR TITLE
feat/1011: 녹화결과 페이지 구현

### DIFF
--- a/src/screens/RecordResultScreen.js
+++ b/src/screens/RecordResultScreen.js
@@ -1,0 +1,101 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { StyleSheet, View, Text, TouchableOpacity, Image } from 'react-native';
+import { useIsFocused } from '@react-navigation/native';
+import { Video } from 'expo-av';
+import * as VideoThumbnails from 'expo-video-thumbnails';
+import { auth } from '../utils/firebase';
+
+export default function RecordResultScreen({ route, navigation }) {
+  const videoRef = useRef(null);
+  const [token, setToken] = useState(null);
+  const { recordedVideo } = route.params;
+  const uri = recordedVideo.uri;
+  const isFocused = useIsFocused();
+
+  useState(async () => {
+    const userToken = await auth.currentUser.getIdToken(true);
+    setToken(userToken);
+  }, []);
+
+  const generateThumbnail = async (videoUrl) => {
+    const { uri } = await VideoThumbnails.getThumbnailAsync(videoUrl, {
+      time: 4000,
+    });
+
+    return uri;
+  };
+
+  const postVideo = async () => {
+    videoRef.current.pauseAsync();
+
+    if (token) {
+      try {
+        const thumbNail = await generateThumbnail(uri);
+
+        navigation.navigate('videoPost', { uri, thumbNail, token });
+      } catch (error) {
+        navigation.goBack();
+      }
+    } else {
+      navigation.navigate('signIn');
+    }
+  };
+
+  useEffect(() => {
+    if (isFocused) {
+      videoRef.current.playAsync();
+    }
+  }, []);
+
+  return (
+    <View style={styles.container}>
+      <Video
+        ref={videoRef}
+        style={styles.video}
+        source={{ uri }}
+        isLooping
+        useNativeControls
+        resizeMode="contain"
+        shouldPlay
+      />
+      <View style={styles.headerContainer}>
+        <View style={styles.buttonBox}>
+          <TouchableOpacity onPress={postVideo} style={styles.button}>
+            <Text style={styles.next}>confirm</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: 'black',
+  },
+  video: {
+    alignSelf: 'center',
+    width: '100%',
+    height: '100%',
+  },
+  headerContainer: {
+    width: '100%',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    top: 0,
+    marginTop: 50,
+    paddingHorizontal: 10,
+    position: 'absolute',
+  },
+  button: {
+    paddingHorizontal: 20,
+    paddingVertical: 10,
+    justifyContent: 'center',
+    borderRadius: 10,
+    backgroundColor: '#FFF',
+  },
+  next: {
+    color: 'black',
+    fontSize: 15,
+  },
+});


### PR DESCRIPTION
## 개요

- [칸반링크](https://www.notion.so/UI-f95ce7fd370d49848958918e7522bf50)
- 녹화할 때의 카메라화면과 녹화 된 동영상의 줌 차이가 있었다. 최대한 차이를 줄이는 방향으로 구현.

## 작업사항
![Screenshot_20220708-111443_Expo Go](https://user-images.githubusercontent.com/102529818/177904403-039bf384-c358-4739-8ec3-9cfe8d1b4d48.jpg)

- 녹화 된 동영상이 자동으로 재생
- 녹화 된 영상이 마음에 들지 않는다면 이전화면 (녹화 페이지)로 돌아갈 수 있다.
- 녹화 된 영상에 이상이 없다면 동영상 업로드 페이지로 이동한다.
