### PR TITLE
feat/1012: 녹화 된 영상 업로드 구현

### DIFF
--- a/src/screens/VideoPostScreen.js
+++ b/src/screens/VideoPostScreen.js
@@ -1,0 +1,144 @@
+import React, { useState } from 'react';
+import {
+  Text,
+  TextInput,
+  View,
+  StyleSheet,
+  Image,
+  TouchableOpacity,
+} from 'react-native';
+import { AntDesign } from '@expo/vector-icons';
+
+import { doc, updateDoc, arrayUnion } from 'firebase/firestore';
+import { auth, db } from '../utils/firebase';
+import { uploadVideo } from '../utils/utils';
+
+import { LoadingState } from '../context/LoadingContext';
+import LoadingCircle from '../components/LoadingCircle';
+
+export default function VideoPostScreen({ route, navigation }) {
+  const [exerciseTitle, setExerciseTitle] = useState('');
+  const [titleError, setTitleError] = useState('');
+  const { loading, setLoading } = LoadingState();
+  const { uri, thumbnail, token } = route.params;
+
+  const handlePost = async () => {
+    if (exerciseTitle === '') {
+      setTitleError('Exercise name required.');
+      return;
+    }
+
+    setLoading(true);
+    const user = auth.currentUser;
+    let videoURL;
+
+    if (uri) {
+      const { uploadedURL, fileName } = await uploadVideo(
+        uri,
+        `videos/${user.uid}`,
+        `${exerciseTitle}`
+      );
+      videoURL = uploadedURL;
+    }
+
+    const videoData = {
+      videos: arrayUnion(...[{ title: exerciseTitle, url: videoURL }]),
+    };
+
+    await Promise.all([
+      updateDoc(doc(db, 'users', user.uid), { ...videoData }),
+    ]);
+
+    setLoading(false);
+    navigation.navigate('mainNav');
+  };
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.header}>
+        <TouchableOpacity
+          onPress={() => navigation.goBack()}
+          style={styles.backButton}
+        >
+          <AntDesign name="left" size={30} color="black" />
+        </TouchableOpacity>
+        <Text style={styles.pageTitle}>Upload Video</Text>
+      </View>
+      <View style={styles.imageContainer}>
+        <Image source={{ uri }} style={styles.mediaPreview} />
+      </View>
+      <View style={styles.infoContainer}>
+        <TextInput
+          style={styles.title}
+          maxLength={50}
+          placeholder="Exercise name"
+          onChangeText={setExerciseTitle}
+        />
+        <Text style={styles.titleErrorText}>{titleError}</Text>
+      </View>
+      <View style={styles.buttonContainer}>
+        <TouchableOpacity onPress={handlePost}>
+          {loading ? (
+            <LoadingCircle />
+          ) : (
+            <AntDesign name="check" style={styles.uploadIcon} />
+          )}
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    paddingTop: 40,
+    backgroundColor: 'white',
+  },
+  header: {
+    height: '9%',
+    flexDirection: 'row',
+  },
+  backButton: {
+    flex: 1,
+    marginLeft: 10,
+  },
+  pageTitle: {
+    flex: 5,
+    fontSize: 20,
+  },
+  imageContainer: {
+    alignItems: 'center',
+    marginTop: 20,
+    borderRadius: 10,
+  },
+  mediaPreview: {
+    aspectRatio: 9 / 16,
+    backgroundColor: 'black',
+    borderRadius: 15,
+    width: '40%',
+  },
+  title: {
+    height: 50,
+    marginBottom: 10,
+  },
+  infoContainer: {
+    margin: 20,
+    flex: 1,
+    flexDirection: 'column',
+    marginRight: 20,
+  },
+  buttonContainer: {
+    alignItems: 'center',
+    right: 5,
+    top: 40,
+    position: 'absolute',
+  },
+  uploadIcon: {
+    fontSize: 38,
+    color: '#2196F3',
+  },
+  titleErrorText: {
+    color: 'red',
+  },
+});

--- a/src/screens/VideoPostScreen.js
+++ b/src/screens/VideoPostScreen.js
@@ -81,7 +81,7 @@ export default function VideoPostScreen({ route, navigation }) {
           {loading ? (
             <LoadingCircle />
           ) : (
-            <AntDesign name="check" style={styles.uploadIcon} />
+            <AntDesign name="cloudupload" style={styles.uploadIcon} />
           )}
         </TouchableOpacity>
       </View>
@@ -96,7 +96,8 @@ const styles = StyleSheet.create({
     backgroundColor: 'white',
   },
   header: {
-    height: '9%',
+    marginTop: 20,
+    height: '10%',
     flexDirection: 'row',
   },
   backButton: {
@@ -135,6 +136,7 @@ const styles = StyleSheet.create({
     position: 'absolute',
   },
   uploadIcon: {
+    marginTop: 20,
     fontSize: 38,
     color: '#2196F3',
   },

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -50,6 +50,33 @@ export const uploadImage = async (uri, path, fName) => {
   return { url, fileName };
 };
 
+export const uploadVideo = async (uri, path, fName) => {
+  const blob = await new Promise((resolve, reject) => {
+    const xhr = new XMLHttpRequest();
+    xhr.onload = function () {
+      resolve(xhr.response);
+    };
+    xhr.onerror = function (e) {
+      console.log(e);
+      reject(new TypeError('Network request failed'));
+    };
+    xhr.responseType = 'blob';
+    xhr.open('GET', uri, true);
+    xhr.send(null);
+  });
+
+  const fileName = fName || nanoid();
+  const videoRef = ref(storage, `${path}/${fileName}.mp4`);
+
+  const snapshot = await uploadBytes(videoRef, blob);
+
+  blob.close();
+
+  const uploadedURL = await getDownloadURL(snapshot.ref);
+
+  return { uploadedURL, fileName };
+};
+
 export const validateEmail = (email) => {
   const emailValidation =
     /^[0-9?A-z0-9?]+(\.)?[0-9?A-z0-9?]+@[0-9?A-z]+\.[A-z]{2}.?[A-z]{0,3}$/;


### PR DESCRIPTION
## 개요

- [칸반링크](https://www.notion.so/4268a4b70690498c9d425ff9c6575b78)
- firebase store에 동영상을 저장하는 작업을 구현하였다.
- expo에서 firebase store에 파일을 저장할 때 예전부터 있던 버그가 있던 것 같다. fetch로 저장요청을 보내면 에러가 발생하고 요청이 수행되지 않는다. 구글링을 통해 xml 요청을 수행하면 가능하다고 해서 우선 해당 방법으로 구현하였다.
- [github issue link](https://github.com/expo/expo/issues/2402#issuecomment-443726662)

## 작업사항
![Screenshot_20220708-112424_Expo Go](https://user-images.githubusercontent.com/102529818/177905718-7c7533a5-1514-4c3b-aee2-4323f0086a54.jpg)

- 녹화한 동영상 업로드 구현
- 뒤로가기를 누르면 다시 동영상 확인 가능
- 운동 이름을 입력하지 않았다면 운동이름이 필요하다는 경고문 출력
- 업로드는 firestore cloud에 저장
- 현재 로그인 한 유저의 uid로 videos목록 업데이트
