### PR TITLE
feat/1014: 트레이너 목록 페이지 구현

### DIFF
--- a/src/screens/Trainers.js
+++ b/src/screens/Trainers.js
@@ -1,10 +1,93 @@
-import { View, Text } from 'react-native';
-import React from 'react';
+import { View, Text, FlatList, Image, StyleSheet } from 'react-native';
+import React, { useEffect, useState } from 'react';
+import { collection, getDocs, where, query } from 'firebase/firestore';
+import { auth, db } from '../utils/firebase';
+import { TouchableOpacity } from 'react-native-gesture-handler';
 
-export default function Trainers() {
+export default function Trainers({ navigation }) {
+  const [trainersData, setTrainersData] = useState([]);
+  const user = auth.currentUser;
+
+  const getTrainersData = async () => {
+    const videoRegisteredUser = [];
+
+    const q = query(collection(db, 'users'), where('videos', '!=', null));
+    const querySnapShot = await getDocs(q);
+
+    querySnapShot.forEach((doc) => {
+      if (doc.data().uid !== user.uid) {
+        videoRegisteredUser.push(doc.data());
+      }
+    });
+
+    setTrainersData(videoRegisteredUser);
+  };
+
+  useEffect(() => {
+    setTrainersData([]);
+    getTrainersData();
+  }, []);
+
+  const renderTrainer = ({ item }) => (
+    <TouchableOpacity
+      onPress={() =>
+        navigation.navigate('trainerExerciseList', {
+          item,
+        })
+      }
+    >
+      <View style={styles.content}>
+        <View style={styles.trainerBox}>
+          <Text style={styles.trainerName}>{item.displayName}</Text>
+          <Image source={{ uri: item.photoURL }} style={styles.profile} />
+        </View>
+      </View>
+    </TouchableOpacity>
+  );
+
   return (
-    <View style={{ marginTop: 40 }}>
-      <Text>Trainers</Text>
+    <View style={styles.container}>
+      <FlatList
+        data={trainersData}
+        renderItem={renderTrainer}
+        keyExtractor={(trainer) => trainer.email}
+        numColumns={1}
+        style={{ marginTop: 50 }}
+      />
     </View>
   );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: 'white',
+  },
+  content: {
+    flex: 1,
+  },
+  trainerBox: {
+    width: '95%',
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    borderWidth: 0.5,
+    borderRadius: 20,
+    margin: 10,
+    padding: 10,
+    paddingLeft: 20,
+    paddingRight: 20,
+  },
+  userInfo: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  profile: {
+    width: 50,
+    height: 50,
+    borderRadius: 25,
+  },
+  trainerName: {
+    paddingLeft: 10,
+  },
+});


### PR DESCRIPTION
## 개요

- [칸반링크](https://www.notion.so/08bfdc910d0e471ba28fa0c80ddf4178)
- 운동을 하나라도 등록한 유저라면 트레이너가 되어 트레이너 목록에 나타나게 된다.
- 아직 flatlist사용에 익숙하지 않아서 배치하는 데 조금의 어려움이 있었다.
- mongodb를 사용하지 않고 firestore database를 사용하므로 새로운 query에 적응하는 데 조금 시간이 걸렸다.

## 작업사항
![Screenshot_20220712-164256_Expo Go](https://user-images.githubusercontent.com/102529818/178437141-476b9808-610b-4c6f-93b8-91afd16d8eed.jpg)

- 트레이너 목록 나타남
- 트레이너를 터치하면 해당 트레이너의 운동 목록으로 넘어가도록 구현

