### PR TITLE
feat/1015: 트레이너 운동리스트 구현

### DIFF
--- a/src/navigation/Home.js
+++ b/src/navigation/Home.js
@@ -10,6 +10,8 @@ import Pose from '../components/Pose';
 import RecordResultScreen from '../screens/RecordResultScreen';
 import Record from '../components/Record';
 import VideoPostScreen from '../screens/VideoPostScreen';
+import TrainerExerciseListScreen from '../screens/TrainerExerciseListScreen';
+import TrainerExerciseScreen from '../screens/TrainerExerciseScreen';
 
 const Stack = createStackNavigator();
 
@@ -60,6 +62,16 @@ export default function Home() {
             <Stack.Screen
               name="exerciseScreen"
               component={ExerciseScreen}
+              options={{ headerShown: false }}
+            />
+            <Stack.Screen
+              name="trainerExerciseList"
+              component={TrainerExerciseListScreen}
+              options={{ headerShown: false }}
+            />
+            <Stack.Screen
+              name="trainerExerciseScreen"
+              component={TrainerExerciseScreen}
               options={{ headerShown: false }}
             />
           </>

--- a/src/screens/TrainerExerciseListScreen.js
+++ b/src/screens/TrainerExerciseListScreen.js
@@ -1,0 +1,65 @@
+import React from 'react';
+import { View, StyleSheet, Image, FlatList } from 'react-native';
+import { TouchableOpacity } from 'react-native-gesture-handler';
+
+export default function TrainerExerciseListScreen({ route, navigation }) {
+  const { videos } = route.params.item;
+
+  const renderTrainerExercise = ({ item }) => (
+    <View style={styles.thumbNailItem}>
+      <TouchableOpacity
+        onPress={() =>
+          navigation.navigate('trainerExerciseScreen', {
+            exerciseData: item,
+          })
+        }
+      >
+        <View style={styles.imageWrapper}>
+          <Image
+            source={{
+              uri: item.thumbnail,
+            }}
+            style={styles.image}
+          />
+        </View>
+      </TouchableOpacity>
+    </View>
+  );
+
+  return (
+    <View style={styles.container}>
+      <FlatList
+        data={videos}
+        renderItem={renderTrainerExercise}
+        keyExtractor={(data) => data.title}
+        numColumns={1}
+        style={{ marginTop: 50 }}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#fff',
+  },
+  imageWrapper: {
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  image: {
+    width: 380,
+    height: 200,
+    borderRadius: 10,
+    borderColor: 'black',
+    borderWidth: 1,
+  },
+  thumbNailItem: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    marginBottom: 25,
+  },
+});


### PR DESCRIPTION
## 개요

- [칸반링크](https://www.notion.so/ee564e226e3647589ee3fcaafa610621)
- 업로드한 동영상의 썸네일을 추출하는데 문제가 있어서 썸네일 추출 로직을 변경하였다. 동영상을 받아와서 썸네일을 추출하는 것이 아닌 동영상 업로드 시에 썸네일을 추출하여 썸네일을 업로드한 후 운동리스트페이지로 들어오면 썸네일을 받아오도록 구현하였다.

## 작업사항
![Screenshot_20220712-164301_Expo Go](https://user-images.githubusercontent.com/102529818/178451150-9ec3415a-769b-4ac6-8567-8e9a5555cac7.jpg)

- 해당 트레이너가 업로드 한 운동리스트 나열
- 동영상의 썸네일이 보이도록 구현
- 해당 동영상을 터치하면 운동이 시작되고 해당 운동에 대한 count등이 시작됨.
